### PR TITLE
refactor: move all codes under com.xiaomi.infra.pegasus.analyser package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
                 </artifactSet>
                 <transformers>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                    <mainClass>com.xiaomi.infra.sample.spark.scanAllData</mainClass>
+                    <mainClass>com.xiaomi.infra.pegasus.analyser.sample.spark.scanAllData</mainClass>
                   </transformer>
                 </transformers>
               </configuration>

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -4,11 +4,7 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 PROJECT_DIR=$(dirname "${SCRIPT_DIR}")
 cd "${PROJECT_DIR}" || exit 1
 
-SRC_FILES=(src/main/java/com/xiaomi/infra/common/*.java
-           src/main/java/com/xiaomi/infra/config/*.java
-           src/main/java/com/xiaomi/infra/service/db/*.java
-           src/main/java/com/xiaomi/infra/service/*.java
-           src/main/java/com/xiaomi/infra/*.java
+SRC_FILES=(src/main/java/com/xiaomi/infra/pegasus/analyser/*.java
            )
 
 if [ ! -f "${PROJECT_DIR}"/google-java-format-1.7-all-deps.jar ]; then

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/Config.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/Config.java
@@ -1,4 +1,4 @@
-package com.xiaomi.infra.config;
+package com.xiaomi.infra.pegasus.analyser;
 
 import java.io.Serializable;
 import java.util.Objects;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/FdsService.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/FdsService.java
@@ -1,6 +1,5 @@
-package com.xiaomi.infra.service;
+package com.xiaomi.infra.pegasus.analyser;
 
-import com.xiaomi.infra.config.Config;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusClient.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusClient.java
@@ -1,8 +1,5 @@
-package com.xiaomi.infra;
+package com.xiaomi.infra.pegasus.analyser;
 
-import com.xiaomi.infra.service.FdsService;
-import com.xiaomi.infra.service.db.PegasusOptions;
-import com.xiaomi.infra.service.db.PegasusScanner;
 import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -20,8 +17,6 @@ public class PegasusClient implements AutoCloseable, PegasusClientInterface {
   private int partitionCounter;
   private Map<Integer, String> checkPointUrls;
   private PegasusScanner pegasusScanner;
-
-  public PegasusClient() {}
 
   public PegasusClient(PegasusOptions options, FdsService fdsService) {
     this.partitionCounter = fdsService.getPartitionCounter();

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusClientInterface.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusClientInterface.java
@@ -1,6 +1,5 @@
-package com.xiaomi.infra;
+package com.xiaomi.infra.pegasus.analyser;
 
-import com.xiaomi.infra.service.db.PegasusScanner;
 import java.io.Serializable;
 import org.rocksdb.RocksDBException;
 

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusKey.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusKey.java
@@ -1,4 +1,4 @@
-package com.xiaomi.infra.service.db;
+package com.xiaomi.infra.pegasus.analyser;
 
 public class PegasusKey {
 

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusOptions.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusOptions.java
@@ -1,6 +1,5 @@
-package com.xiaomi.infra.service.db;
+package com.xiaomi.infra.pegasus.analyser;
 
-import com.xiaomi.infra.config.Config;
 import org.rocksdb.Env;
 import org.rocksdb.HdfsEnv;
 import org.rocksdb.InfoLogLevel;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusScanner.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/PegasusScanner.java
@@ -1,6 +1,5 @@
-package com.xiaomi.infra.service.db;
+package com.xiaomi.infra.pegasus.analyser;
 
-import com.xiaomi.infra.common.Utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/Utils.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/Utils.java
@@ -1,4 +1,4 @@
-package com.xiaomi.infra.common;
+package com.xiaomi.infra.pegasus.analyser;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/local/ScanTool.java
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/local/ScanTool.java
@@ -1,11 +1,11 @@
-package com.xiaomi.infra.sample.local;
+package com.xiaomi.infra.pegasus.analyser.sample.local;
 
-import com.xiaomi.infra.PegasusClient;
-import com.xiaomi.infra.config.Config;
-import com.xiaomi.infra.service.FdsService;
-import com.xiaomi.infra.service.db.PegasusKey;
-import com.xiaomi.infra.service.db.PegasusOptions;
-import com.xiaomi.infra.service.db.PegasusScanner;
+import com.xiaomi.infra.pegasus.analyser.PegasusClient;
+import com.xiaomi.infra.pegasus.analyser.Config;
+import com.xiaomi.infra.pegasus.analyser.FdsService;
+import com.xiaomi.infra.pegasus.analyser.PegasusKey;
+import com.xiaomi.infra.pegasus.analyser.PegasusOptions;
+import com.xiaomi.infra.pegasus.analyser.PegasusScanner;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/countAllData.scala
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/countAllData.scala
@@ -1,10 +1,6 @@
 package com.xiaomi.infra.pegasus.analyser.sample.spark
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.xiaomi.infra.pegasus.analyser.{Config, FdsService, PegasusClient, PegasusOptions}
-import com.xiaomi.infra.{FdsService, PegasusClient, PegasusOptions}
-import com.xiaomi.infra.pegasus.analyser.sample.local.ScanTool
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.rocksdb.RocksDB

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/countAllData.scala
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/countAllData.scala
@@ -1,12 +1,10 @@
-package com.xiaomi.infra.sample.spark
+package com.xiaomi.infra.pegasus.analyser.sample.spark
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.xiaomi.infra.PegasusClient
-import com.xiaomi.infra.config.Config
-import com.xiaomi.infra.sample.local.ScanTool
-import com.xiaomi.infra.service.FdsService
-import com.xiaomi.infra.service.db.PegasusOptions
+import com.xiaomi.infra.pegasus.analyser.{Config, FdsService, PegasusClient, PegasusOptions}
+import com.xiaomi.infra.{FdsService, PegasusClient, PegasusOptions}
+import com.xiaomi.infra.pegasus.analyser.sample.local.ScanTool
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.rocksdb.RocksDB

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/scanAllData.scala
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/scanAllData.scala
@@ -1,7 +1,6 @@
 package com.xiaomi.infra.pegasus.analyser.sample.spark
 
 import com.xiaomi.infra.pegasus.analyser.{Config, FdsService, PegasusClient, PegasusOptions}
-import com.xiaomi.infra.{FdsService, PegasusClient, PegasusOptions}
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.rocksdb.RocksDB

--- a/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/scanAllData.scala
+++ b/src/main/java/com/xiaomi/infra/pegasus/analyser/sample/spark/scanAllData.scala
@@ -1,9 +1,7 @@
-package com.xiaomi.infra.sample.spark
+package com.xiaomi.infra.pegasus.analyser.sample.spark
 
-import com.xiaomi.infra.PegasusClient
-import com.xiaomi.infra.config.Config
-import com.xiaomi.infra.service.FdsService
-import com.xiaomi.infra.service.db.PegasusOptions
+import com.xiaomi.infra.pegasus.analyser.{Config, FdsService, PegasusClient, PegasusOptions}
+import com.xiaomi.infra.{FdsService, PegasusClient, PegasusOptions}
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.{SparkConf, SparkContext, TaskContext}
 import org.rocksdb.RocksDB


### PR DESCRIPTION
Keep package name consistent with java-client (`com.xiaomi.infra.pegasus.client`)